### PR TITLE
fix: detect unexpected fields in reference evidence comparison

### DIFF
--- a/cardiff/src/cardiff/cli.py
+++ b/cardiff/src/cardiff/cli.py
@@ -557,9 +557,16 @@ def compare_reference_evidence(
     reference_payload: dict[str, object],
     reference_path: Path,
 ) -> ReferenceComparison:
-    """Compare current render evidence against a stored reference payload."""
+    """Compare current render evidence against a stored reference payload.
+
+    Both payloads must have identical keys for a match. If either payload
+    contains fields not present in the other, or if any field values differ,
+    the comparison returns a mismatch.
+    """
 
     mismatches: list[dict[str, object]] = []
+
+    # Check for missing fields in current payload (present in reference but not current)
     for field_name in sorted(reference_payload):
         actual_value = current_payload.get(field_name)
         expected_value = reference_payload[field_name]
@@ -571,6 +578,17 @@ def compare_reference_evidence(
                     'actual': actual_value,
                 }
             )
+
+    # Check for unexpected fields in current payload (present in current but not reference)
+    unexpected_fields = set(current_payload.keys()) - set(reference_payload.keys())
+    for field_name in sorted(unexpected_fields):
+        mismatches.append(
+            {
+                'field': field_name,
+                'expected': None,
+                'actual': current_payload[field_name],
+            }
+        )
 
     return ReferenceComparison(
         status='match' if not mismatches else 'mismatch',

--- a/cardiff/tests/cli/test_cli.py
+++ b/cardiff/tests/cli/test_cli.py
@@ -224,7 +224,7 @@ import sys
 from pathlib import Path
 from contextlib import redirect_stderr, redirect_stdout
 
-from cardiff.cli import main
+from cardiff.cli import main, compare_reference_evidence
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 FIXTURES_ROOT = Path(__file__).resolve().parents[1] / 'fixtures'
@@ -376,3 +376,72 @@ def test_python_dash_m_entrypoint_supports_validate_command():
     assert payload['command'] == 'validate'
     assert payload['status'] == 'accepted'
     assert payload['template_id'] == 'business-card'
+
+
+# ==============================================================================
+# Tests for compare_reference_evidence (fixes #8)
+# ==============================================================================
+
+
+def test_compare_reference_evidence_returns_match_when_payloads_are_identical():
+    """When current and reference have the same keys and values, status is match."""
+    current = {'a': 1, 'b': 'hello'}
+    reference = {'a': 1, 'b': 'hello'}
+    result = compare_reference_evidence(current, reference, Path('ref.json'))
+
+    assert result.status == 'match'
+    assert result.mismatches == ()
+
+
+def test_compare_reference_evidence_detects_missing_fields_in_current():
+    """When reference has fields missing from current, status is mismatch."""
+    current = {'a': 1}
+    reference = {'a': 1, 'b': 2}
+    result = compare_reference_evidence(current, reference, Path('ref.json'))
+
+    assert result.status == 'mismatch'
+    assert len(result.mismatches) == 1
+    assert result.mismatches[0]['field'] == 'b'
+    assert result.mismatches[0]['expected'] == 2
+    assert result.mismatches[0]['actual'] is None
+
+
+def test_compare_reference_evidence_detects_unexpected_fields_in_current():
+    """When current has extra fields not in reference, status is mismatch."""
+    current = {'a': 1, 'b': 2}
+    reference = {'a': 1}
+    result = compare_reference_evidence(current, reference, Path('ref.json'))
+
+    assert result.status == 'mismatch'
+    assert len(result.mismatches) == 1
+    assert result.mismatches[0]['field'] == 'b'
+    assert result.mismatches[0]['expected'] is None
+    assert result.mismatches[0]['actual'] == 2
+
+
+def test_compare_reference_evidence_detects_value_differences():
+    """When a field exists in both but values differ, status is mismatch."""
+    current = {'a': 1, 'b': 'changed'}
+    reference = {'a': 1, 'b': 'original'}
+    result = compare_reference_evidence(current, reference, Path('ref.json'))
+
+    assert result.status == 'mismatch'
+    assert len(result.mismatches) == 1
+    assert result.mismatches[0]['field'] == 'b'
+    assert result.mismatches[0]['expected'] == 'original'
+    assert result.mismatches[0]['actual'] == 'changed'
+
+
+def test_compare_reference_evidence_reports_multiple_mismatches():
+    """When multiple fields differ, all are reported."""
+    current = {'a': 99, 'c': 'extra'}
+    reference = {'a': 1, 'b': 'missing'}
+    result = compare_reference_evidence(current, reference, Path('ref.json'))
+
+    assert result.status == 'mismatch'
+    # Should have 3 mismatches: 'a' value differs, 'b' missing from current, 'c' extra in current
+    assert len(result.mismatches) == 3
+
+    fields = {m['field'] for m in result.mismatches}
+    assert fields == {'a', 'b', 'c'}
+


### PR DESCRIPTION
## Summary
This PR fixes the bug reported in #8 where `compare_reference_evidence()` would return a false `match` status when the current payload contained extra fields not present in the reference.

## Problem
The original implementation only iterated over keys from the reference payload:

```python
for field_name in sorted(reference_payload):
    # only checks reference keys
```

This meant that if the current payload had extra fields (schema drift), the comparison would still return `match` because those extra fields were never examined.

## Solution
Added a second pass to detect unexpected fields:

```python
# Check for unexpected fields in current payload (present in current but not reference)
unexpected_fields = set(current_payload.keys()) - set(reference_payload.keys())
for field_name in sorted(unexpected_fields):
    mismatches.append({
        'field': field_name,
        'expected': None,
        'actual': current_payload[field_name],
    })
```

Now the comparison is strict: both payloads must have identical key sets for a match.

## Tests Added
Added 5 new unit tests to `cardiff/tests/cli/test_cli.py`:

1. `test_compare_reference_evidence_returns_match_when_payloads_are_identical`
2. `test_compare_reference_evidence_detects_missing_fields_in_current`  
3. `test_compare_reference_evidence_detects_unexpected_fields_in_current` ← **the main fix**
4. `test_compare_reference_evidence_detects_value_differences`
5. `test_compare_reference_evidence_reports_multiple_mismatches`

## Verification
The reproduction case from the issue now returns the expected result:

```python
from pathlib import Path
from cardiff.cli import compare_reference_evidence

result = compare_reference_evidence({'a': 1, 'b': 2}, {'a': 1}, Path('ref.json'))
print(result.to_dict())
# Before: {'status': 'match', 'reference_path': 'ref.json'}
# After:  {'status': 'mismatch', 'reference_path': 'ref.json', 'mismatches': ({'field': 'b', 'expected': None, 'actual': 2},)}
```

Fixes #8