### PR TITLE
feat: implement QR code support

### DIFF
--- a/cardiff/pyproject.toml
+++ b/cardiff/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "PyYAML>=6,<7",
+    "segno>=1.6,<2",
 ]
 
 [project.optional-dependencies]

--- a/cardiff/src/cardiff/rendering/__init__.py
+++ b/cardiff/src/cardiff/rendering/__init__.py
@@ -1,5 +1,11 @@
 """Public rendering surface for Cardiff."""
 
+from .directives import (
+    build_vcard,
+    generate_qr_png,
+    resolve_qr_directives,
+    resolve_qr_directives_deterministic,
+)
 from .models import (
     NormalizedRenderEvidence,
     RenderFailureClass,
@@ -21,9 +27,13 @@ __all__ = [
     "ResolvedTemplate",
     "TemplateDescriptor",
     "XeLaTeXAdapter",
+    "build_vcard",
+    "generate_qr_png",
     "get_default_template_root",
     "get_default_tex_adapter",
     "render_request_to_pdf",
     "resolve_asset_paths",
+    "resolve_qr_directives",
+    "resolve_qr_directives_deterministic",
     "resolve_template",
 ]

--- a/cardiff/src/cardiff/rendering/directives.py
+++ b/cardiff/src/cardiff/rendering/directives.py
@@ -1,0 +1,82 @@
+"""Cardiff custom directives resolved before TeX compilation."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from cardiff.contract.models import IdentityProfile
+
+CARDIFF_QR_PATTERN = re.compile(r"\\cardiffqr\[([^\]]*)\]")
+
+
+def build_vcard(identity: IdentityProfile) -> str:
+    """Build a vCard 3.0 payload from identity fields."""
+
+    lines = [
+        "BEGIN:VCARD",
+        "VERSION:3.0",
+        f"FN:{identity.full_name}",
+        f"TITLE:{identity.role}",
+        f"EMAIL:{identity.email}",
+    ]
+    if identity.organization and identity.department:
+        lines.append(f"ORG:{identity.organization};{identity.department}")
+    elif identity.organization:
+        lines.append(f"ORG:{identity.organization}")
+    if identity.phone:
+        lines.append(f"TEL:{identity.phone}")
+    if identity.website:
+        lines.append(f"URL:{identity.website}")
+    if identity.address_lines:
+        street = ", ".join(identity.address_lines)
+        lines.append(f"ADR:;;{street};;;;")
+    if identity.pronouns:
+        lines.append(f"NOTE:Pronouns: {identity.pronouns}")
+    lines.append("END:VCARD")
+    return "\r\n".join(lines)
+
+
+def generate_qr_png(data: str, output_path: Path, *, scale: int = 4) -> Path:
+    """Generate a QR code PNG using segno."""
+
+    import segno
+
+    qr = segno.make(data, error="M")
+    qr.save(str(output_path), kind="png", scale=scale, border=1)
+    return output_path
+
+
+def resolve_qr_directives(
+    tex_source: str,
+    identity: IdentityProfile,
+    *,
+    include_qr: bool,
+    work_dir: Path,
+) -> str:
+    """Resolve \\cardiffqr[...] directives by generating a QR PNG."""
+
+    if not include_qr:
+        return CARDIFF_QR_PATTERN.sub("", tex_source)
+
+    vcard = build_vcard(identity)
+    qr_path = generate_qr_png(vcard, work_dir / "cardiff-qr.png")
+
+    def _replace(match: re.Match[str]) -> str:
+        options = match.group(1)
+        return f"\\includegraphics[{options}]{{{qr_path.as_posix()}}}"
+
+    return CARDIFF_QR_PATTERN.sub(_replace, tex_source)
+
+
+def resolve_qr_directives_deterministic(
+    tex_source: str,
+    *,
+    include_qr: bool,
+) -> str:
+    """Resolve \\cardiffqr[...] for deterministic adapter (no image I/O)."""
+
+    if not include_qr:
+        return CARDIFF_QR_PATTERN.sub("", tex_source)
+
+    return CARDIFF_QR_PATTERN.sub("% cardiffqr: enabled (deterministic)", tex_source)

--- a/cardiff/src/cardiff/rendering/pipeline.py
+++ b/cardiff/src/cardiff/rendering/pipeline.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
+import tempfile
 from pathlib import Path
 import re
 
 from cardiff.contract.models import RenderRequest
 
+from .directives import resolve_qr_directives, resolve_qr_directives_deterministic
 from .models import (
     NormalizedRenderEvidence,
     RenderFailureClass,
@@ -47,25 +50,44 @@ def render_request_to_pdf(
         placeholder_values = _build_placeholder_values(render_request, resolved_assets)
         template_source = resolved_template.entrypoint_path.read_text(encoding="utf-8")
         rendered_tex = _render_template_source(template_source, placeholder_values)
-        preview_lines = _build_preview_lines(render_request, resolved_assets)
-        compile_artifact = adapter.compile(
-            rendered_tex,
-            output_path,
-            page_size_pt=(
-                resolved_template.descriptor.page_width_pt,
-                resolved_template.descriptor.page_height_pt,
-            ),
-            preview_lines=preview_lines,
-            title=resolved_template.descriptor.display_name,
-        )
-        if (
-            not compile_artifact.output_path.exists()
-            or compile_artifact.output_path.stat().st_size == 0
-        ):
-            raise RenderingError(
-                RenderFailureClass.RENDER_OUTPUT_INVALID,
-                "adapter reported success but did not produce a non-empty PDF artifact",
+
+        include_qr = bool(render_request.template.options.get("include_qr", False))
+
+        with contextlib.ExitStack() as stack:
+            if adapter.deterministic:
+                rendered_tex = resolve_qr_directives_deterministic(
+                    rendered_tex, include_qr=include_qr,
+                )
+            else:
+                qr_tmp = Path(stack.enter_context(
+                    tempfile.TemporaryDirectory(prefix="cardiff-qr-")
+                ))
+                rendered_tex = resolve_qr_directives(
+                    rendered_tex,
+                    render_request.identity,
+                    include_qr=include_qr,
+                    work_dir=qr_tmp,
+                )
+
+            preview_lines = _build_preview_lines(render_request, resolved_assets)
+            compile_artifact = adapter.compile(
+                rendered_tex,
+                output_path,
+                page_size_pt=(
+                    resolved_template.descriptor.page_width_pt,
+                    resolved_template.descriptor.page_height_pt,
+                ),
+                preview_lines=preview_lines,
+                title=resolved_template.descriptor.display_name,
             )
+            if (
+                not compile_artifact.output_path.exists()
+                or compile_artifact.output_path.stat().st_size == 0
+            ):
+                raise RenderingError(
+                    RenderFailureClass.RENDER_OUTPUT_INVALID,
+                    "adapter reported success but did not produce a non-empty PDF artifact",
+                )
 
         evidence = NormalizedRenderEvidence(
             template_id=template_id,
@@ -121,7 +143,6 @@ def _build_placeholder_values(
         "pronouns": identity.pronouns or "",
         "address_block": r" \\ ".join(address_lines),
         "variant": str(options.get("variant", "default")),
-        "include_qr": "enabled" if bool(options.get("include_qr", False)) else "disabled",
         "accent_hex": str(options.get("accent_hex", "#000000")),
         "logo_path": logo_path.as_posix() if logo_path is not None else "",
     }

--- a/cardiff/src/cardiff/rendering/tex.py
+++ b/cardiff/src/cardiff/rendering/tex.py
@@ -27,6 +27,7 @@ class BaseTeXAdapter:
 
     runtime_name = "base-tex-adapter"
     runtime_version = "0"
+    deterministic = False
 
     def compile(
         self,
@@ -45,6 +46,7 @@ class DeterministicTeXAdapter(BaseTeXAdapter):
 
     runtime_name = "deterministic-tex-adapter"
     runtime_version = "1"
+    deterministic = True
 
     def compile(
         self,

--- a/cardiff/src/cardiff/templates/business-card/card.tex
+++ b/cardiff/src/cardiff/templates/business-card/card.tex
@@ -1,5 +1,6 @@
 \documentclass[9pt]{article}
 \usepackage[paperwidth=3.5in,paperheight=2in,margin=0.12in]{geometry}
+\usepackage{graphicx}
 \pagestyle{empty}
 \begin{document}
 \raggedright
@@ -10,5 +11,5 @@
 {{ address_block }}\\
 Variant: {{ variant }}\\
 Accent: {{ accent_hex }}\\
-QR: {{ include_qr }}
+\cardiffqr[width=0.6in]
 \end{document}

--- a/cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json
+++ b/cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json
@@ -1,8 +1,8 @@
 {
   "template_id": "business-card",
-  "manifest_fingerprint": "417786f4a3a024f8bf45611fa5ef4ab6a02e2fb16b5b21ff2da32bf435107690",
-  "request_fingerprint": "e4a1f072d761fd56851fb3719f17257449299b89c0f8ceb13fb40dea769ad1a1",
-  "tex_fingerprint": "e4d78bb45191b951fbed30775162cca1a14014bcce0ad90ef0869ece9246cd60",
+  "manifest_fingerprint": "eb182c553dec2a88f24dc52df2b8745170e0ebfe8f09bec3e2edecb8cc5fb498",
+  "request_fingerprint": "3f26c4b5b1ac75792a7693a934be54291b9e543acb7e58041d0d67c8d50b2e58",
+  "tex_fingerprint": "9994df901f3f8055b1016496bb0bb98bff907cc65760413080918c672091dfc3",
   "pdf_fingerprint": "89eb5b2f53a4a2eaa410c3c448c59ca749022f7bc83b181e62e9f0927b853567",
   "runtime_name": "deterministic-tex-adapter",
   "runtime_version": "1",

--- a/cardiff/tests/rendering/test_directives.py
+++ b/cardiff/tests/rendering/test_directives.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+
+from cardiff.contract.models import IdentityProfile
+from cardiff.rendering.directives import (
+    build_vcard,
+    generate_qr_png,
+    resolve_qr_directives,
+    resolve_qr_directives_deterministic,
+)
+
+
+def _make_identity(**overrides) -> IdentityProfile:
+    defaults = {
+        "full_name": "Ada Lovelace",
+        "role": "Computing Pioneer",
+        "email": "ada@example.com",
+        "organization": "Analytical Engine Lab",
+    }
+    defaults.update(overrides)
+    return IdentityProfile(**defaults)
+
+
+class TestBuildVcard:
+    def test_includes_required_fields(self):
+        vcard = build_vcard(_make_identity())
+        assert "FN:Ada Lovelace" in vcard
+        assert "TITLE:Computing Pioneer" in vcard
+        assert "EMAIL:ada@example.com" in vcard
+        assert vcard.startswith("BEGIN:VCARD")
+        assert vcard.endswith("END:VCARD")
+
+    def test_includes_optional_fields(self):
+        identity = _make_identity(
+            phone="+1-555-0100",
+            website="https://ada.example.com",
+            department="Mathematics",
+            address_lines=("123 Logic St.", "London"),
+            pronouns="she/her",
+        )
+        vcard = build_vcard(identity)
+        assert "TEL:+1-555-0100" in vcard
+        assert "URL:https://ada.example.com" in vcard
+        assert "ORG:Analytical Engine Lab;Mathematics" in vcard
+        assert "ADR:;;123 Logic St., London;;;;" in vcard
+        assert "NOTE:Pronouns: she/her" in vcard
+
+    def test_omits_absent_optional_fields(self):
+        identity = _make_identity(organization=None)
+        vcard = build_vcard(identity)
+        assert "ORG:" not in vcard
+        assert "TEL:" not in vcard
+        assert "URL:" not in vcard
+        assert "ADR:" not in vcard
+
+
+class TestGenerateQrPng:
+    def test_creates_valid_png(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = generate_qr_png("hello", Path(tmp) / "test.png")
+            assert path.exists()
+            assert path.read_bytes()[:4] == b"\x89PNG"
+
+
+class TestResolveQrDirectives:
+    def test_enabled_replaces_with_includegraphics(self):
+        tex = r"before \cardiffqr[width=0.6in] after"
+        with tempfile.TemporaryDirectory() as tmp:
+            result = resolve_qr_directives(
+                tex, _make_identity(), include_qr=True, work_dir=Path(tmp),
+            )
+        assert r"\includegraphics[width=0.6in]" in result
+        assert "before" in result
+        assert "after" in result
+        assert r"\cardiffqr" not in result
+
+    def test_disabled_emits_nothing(self):
+        tex = r"before \cardiffqr[width=0.6in] after"
+        with tempfile.TemporaryDirectory() as tmp:
+            result = resolve_qr_directives(
+                tex, _make_identity(), include_qr=False, work_dir=Path(tmp),
+            )
+        assert r"\includegraphics" not in result
+        assert r"\cardiffqr" not in result
+        assert "before  after" in result
+
+    def test_options_pass_through(self):
+        tex = r"\cardiffqr[height=1in,keepaspectratio]"
+        with tempfile.TemporaryDirectory() as tmp:
+            result = resolve_qr_directives(
+                tex, _make_identity(), include_qr=True, work_dir=Path(tmp),
+            )
+        assert r"\includegraphics[height=1in,keepaspectratio]" in result
+
+
+class TestResolveQrDirectivesDeterministic:
+    def test_enabled_emits_comment(self):
+        tex = r"before \cardiffqr[width=0.6in] after"
+        result = resolve_qr_directives_deterministic(tex, include_qr=True)
+        assert "% cardiffqr: enabled (deterministic)" in result
+        assert r"\cardiffqr" not in result
+
+    def test_disabled_emits_nothing(self):
+        tex = r"before \cardiffqr[width=0.6in] after"
+        result = resolve_qr_directives_deterministic(tex, include_qr=False)
+        assert r"\cardiffqr" not in result
+        assert "cardiffqr" not in result
+        assert "before  after" in result


### PR DESCRIPTION
This PR implements QR code generation to the business card rendering pipeline. The approach uses a Python-based rendering to ensure out-of-the-box support without relying on a third-party LaTeX plugin. To make this possible in TeX-based templates, a custom directive approach is implemented so that templates can just call `\cardiffqr` instead of `\\includegraphics{<location of qr>}`. Also added tests

Closes #6 