### PR TITLE
Fail clearly on non-ASCII text in deterministic fallback

### DIFF
--- a/cardiff/src/cardiff/rendering/tex.py
+++ b/cardiff/src/cardiff/rendering/tex.py
@@ -169,6 +169,10 @@ def _build_minimal_pdf(
     page_size_pt: tuple[float, float],
     title: str,
 ) -> bytes:
+    _ensure_ascii_preview_text(title, field_name="title")
+    for index, line in enumerate(preview_lines):
+        _ensure_ascii_preview_text(line, field_name=f"preview_lines[{index}]")
+
     width_pt, height_pt = page_size_pt
     y = height_pt - 18.0
     commands = ["BT", "/F1 9 Tf"]
@@ -213,8 +217,21 @@ def _build_minimal_pdf(
 
 
 def _escape_pdf_text(value: str) -> str:
-    escaped = value.encode("ascii", errors="replace").decode("ascii")
+    escaped = value.encode("ascii").decode("ascii")
     escaped = escaped.replace("\\", r"\\")
     escaped = escaped.replace("(", r"\(")
     escaped = escaped.replace(")", r"\)")
     return escaped
+
+
+def _ensure_ascii_preview_text(value: str, *, field_name: str) -> None:
+    try:
+        value.encode("ascii")
+    except UnicodeEncodeError as error:
+        raise RenderingError(
+            RenderFailureClass.TEX_COMPILE_FAILED,
+            (
+                "deterministic adapter cannot render non-ASCII text in "
+                f"{field_name}; install xelatex for Unicode-safe rendering"
+            ),
+        ) from error

--- a/cardiff/tests/rendering/test_pipeline.py
+++ b/cardiff/tests/rendering/test_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -143,3 +144,24 @@ def test_non_deterministic_qr_renders_keep_normalized_evidence_stable():
     assert first.rendered_tex is not None
     assert ".cardiff-qr/qr-evidence-stability-cardiff-qr.png" in first.rendered_tex
     assert first.evidence.to_dict() == second.evidence.to_dict()
+
+
+def test_deterministic_adapter_fails_clearly_on_non_ascii_identity_text():
+    request = _load_request()
+    unicode_request = replace(
+        request,
+        identity=replace(request.identity, full_name="José Álvarez"),
+    )
+    output_path = APPROVED_SAMPLES / "unicode-name.pdf"
+
+    result = render_request_to_pdf(
+        unicode_request,
+        output_path,
+        approved_asset_roots=(APPROVED_ASSETS,),
+        tex_adapter=DeterministicTeXAdapter(),
+    )
+
+    assert result.status == RenderStatus.FAILED
+    assert result.failure_class == RenderFailureClass.TEX_COMPILE_FAILED
+    assert result.output_path is None
+    assert any("non-ASCII" in message for message in result.diagnostics)


### PR DESCRIPTION
Fixes #10 where the deterministic fallback adapter could silently corrupt non-ASCII identity text during PDF generation.

### Changes
- added a guard in the deterministic PDF builder to detect non-ASCII preview and title text before serialization
- changed the deterministic adapter to raise a clear TEX_COMPILE_FAILED error when Unicode text cannot be safely rendered
- added a regression test covering a non-ASCII identity name in deterministic mode

### Tested with:
```
python -m pytest tests/rendering/test_pipeline.py -k non_ascii
python -m pytest tests/rendering/test_pipeline.py tests/rendering/test_determinism.py
```