### PR TITLE
fix: align asset root validation with render behavior

### DIFF
--- a/cardiff/src/cardiff/contract/validation.py
+++ b/cardiff/src/cardiff/contract/validation.py
@@ -224,6 +224,8 @@ from pathlib import Path
 import re
 from urllib.parse import urlparse
 
+from cardiff.paths import normalize_approved_asset_roots
+
 from .errors import ValidationCode, ValidationOutcome
 from .models import (
     AssetReference,
@@ -268,7 +270,7 @@ def validate_render_request(
     """Validate a parsed mapping and return a sanitized canonical request."""
 
     issues: list[ValidationIssue] = []
-    approved_roots = tuple(Path(root) for root in (approved_asset_roots or (Path("assets"),)))
+    approved_roots = normalize_approved_asset_roots(tuple(approved_asset_roots or ()))
 
     if not isinstance(payload, Mapping):
         issues.append(
@@ -367,6 +369,7 @@ def validate_asset_reference(
 
     slot = asset_reference.slot
     candidate = asset_reference.path
+    resolved_roots = normalize_approved_asset_roots(tuple(approved_roots))
 
     if slot not in ASSET_SLOTS:
         return _finalize_issues(
@@ -394,7 +397,7 @@ def validate_asset_reference(
     asset_path = Path(candidate)
     if asset_path.is_absolute():
         normalized = asset_path.resolve()
-        if not any(normalized.is_relative_to(Path(root).resolve()) for root in approved_roots):
+        if not any(normalized.is_relative_to(root) for root in resolved_roots):
             return _finalize_issues(
                 [
                     ValidationIssue(
@@ -405,6 +408,16 @@ def validate_asset_reference(
                 ]
             )
     else:
+        if not resolved_roots:
+            return _finalize_issues(
+                [
+                    ValidationIssue(
+                        code=ValidationCode.INVALID_ASSET_PATH,
+                        field=f"assets.{slot}",
+                        message="relative asset paths require at least one approved root",
+                    )
+                ]
+            )
         if ".." in asset_path.parts:
             return _finalize_issues(
                 [

--- a/cardiff/src/cardiff/paths.py
+++ b/cardiff/src/cardiff/paths.py
@@ -1,0 +1,13 @@
+"""Shared filesystem path helpers for Cardiff."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def normalize_approved_asset_roots(
+    approved_asset_roots: tuple[str | Path, ...] | None,
+) -> tuple[Path, ...]:
+    """Resolve approved asset roots into a canonical tuple of absolute paths."""
+
+    return tuple(Path(root).resolve() for root in (approved_asset_roots or ()))

--- a/cardiff/src/cardiff/rendering/templates.py
+++ b/cardiff/src/cardiff/rendering/templates.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from cardiff.contract.models import RenderRequest, TemplateSelection
+from cardiff.paths import normalize_approved_asset_roots
 
 from .models import (
     RenderFailureClass,
@@ -82,7 +83,7 @@ def resolve_asset_paths(
 ) -> dict[str, Path]:
     """Resolve request asset references against approved roots and template rules."""
 
-    approved_roots = tuple(Path(root).resolve() for root in (approved_asset_roots or ()))
+    approved_roots = normalize_approved_asset_roots(approved_asset_roots)
     resolved_assets: dict[str, Path] = {}
 
     expected_slots = tuple(dict.fromkeys((*resolved_template.descriptor.required_asset_slots, *resolved_template.descriptor.optional_asset_slots)))

--- a/cardiff/tests/cli/test_cli.py
+++ b/cardiff/tests/cli/test_cli.py
@@ -286,6 +286,25 @@ def test_validate_command_returns_structured_issues_for_invalid_request():
     assert 'Validation rejected' in stderr
 
 
+def test_validate_command_rejects_relative_assets_without_approved_roots():
+    exit_code, payload, stderr = _run_cli(
+        [
+            'validate',
+            VALID_REQUEST.as_posix(),
+        ]
+    )
+
+    assert exit_code == 1
+    assert payload['command'] == 'validate'
+    assert payload['status'] == 'rejected'
+    assert payload['template_id'] == 'business-card'
+    assert payload['exit_code'] == 1
+    assert payload['issue_count'] == 1
+    assert payload['issues'][0]['code'] == 'invalid_asset_path'
+    assert payload['issues'][0]['field'] == 'assets.logo'
+    assert 'Validation rejected' in stderr
+
+
 def test_render_command_writes_the_requested_pdf_and_reports_runtime_metadata():
     exit_code, payload, stderr = _run_cli(
         [
@@ -350,6 +369,30 @@ def test_render_command_stops_when_validation_fails():
     assert payload['command'] == 'render'
     assert payload['status'] == 'rejected'
     assert payload['failure_stage'] == 'validation'
+    assert not INVALID_OUTPUT_PATH.exists()
+    assert 'failed validation' in stderr
+
+
+def test_render_command_rejects_relative_assets_without_approved_roots():
+    assert not INVALID_OUTPUT_PATH.exists()
+
+    exit_code, payload, stderr = _run_cli(
+        [
+            'render',
+            VALID_REQUEST.as_posix(),
+            '--output',
+            INVALID_OUTPUT_PATH.as_posix(),
+            '--deterministic',
+        ]
+    )
+
+    assert exit_code == 1
+    assert payload['command'] == 'render'
+    assert payload['status'] == 'rejected'
+    assert payload['failure_stage'] == 'validation'
+    assert payload['issue_count'] == 1
+    assert payload['issues'][0]['code'] == 'invalid_asset_path'
+    assert payload['issues'][0]['field'] == 'assets.logo'
     assert not INVALID_OUTPUT_PATH.exists()
     assert 'failed validation' in stderr
 

--- a/cardiff/tests/contract/test_validation.py
+++ b/cardiff/tests/contract/test_validation.py
@@ -310,3 +310,27 @@ template:
         "template.options.accent_hex",
         "template.options.include_qr",
     ]
+
+
+def test_relative_asset_paths_are_rejected_without_approved_roots():
+    payload = """
+identity:
+  full_name: "Ada Lovelace"
+  role: "Engineer"
+  email: "ada@example.com"
+template:
+  id: business-card
+assets:
+  logo: "brand/logo.png"
+"""
+
+    result = load_and_validate_request(
+        payload,
+        source_name="invalid.yaml",
+    )
+
+    assert result.outcome == ValidationOutcome.REJECTED
+    assert result.request is None
+    assert len(result.issues) == 1
+    assert result.issues[0].code == ValidationCode.INVALID_ASSET_PATH
+    assert result.issues[0].field == "assets.logo"

--- a/cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json
+++ b/cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json
@@ -1,7 +1,7 @@
 {
   "template_id": "business-card",
   "manifest_fingerprint": "eb182c553dec2a88f24dc52df2b8745170e0ebfe8f09bec3e2edecb8cc5fb498",
-  "request_fingerprint": "3f26c4b5b1ac75792a7693a934be54291b9e543acb7e58041d0d67c8d50b2e58",
+  "request_fingerprint": "5f17d60337facebf5c43813e984c060230572c9e36eb5dc23dda533391a8feea",
   "tex_fingerprint": "9994df901f3f8055b1016496bb0bb98bff907cc65760413080918c672091dfc3",
   "pdf_fingerprint": "89eb5b2f53a4a2eaa410c3c448c59ca749022f7bc83b181e62e9f0927b853567",
   "runtime_name": "deterministic-tex-adapter",


### PR DESCRIPTION
Fix Issue #9: Align Asset Root Validation With Render Behavior

**Problem**
cardiff validate and cardiff render disagreed on default approved asset roots. A request could pass validation and then fail during render when --approved-asset-root was omitted.

**Approach**
Removed the hidden validation fallback, so relative asset paths now require an explicit approved root in both commands. Added regression tests and centralized approved-root normalization in a shared helper.

**Validation**
`./.venv/bin/python -m pytest tests -q -p no:cacheprovider -> 33 passed`

**Approved Render Evidence**
Refreshed. The stored request_fingerprint in approved reference evidence was updated to match the current canonical request payload.

**Risks / Follow-Up**
This is a stricter behavior change for users who relied on the old implicit fallback. A small follow-up would be improving the CLI error text to explicitly suggest --approved-asset-root.