### PR TITLE
feat: implement CI/CD for pull requests and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main, rev]
+  pull_request:
+    branches: [rev]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        working-directory: cardiff
+        run: pip install -e ".[dev]"
+
+      - name: Clean temporary QR work directories
+        working-directory: cardiff
+        run: |
+          find tests/fixtures/approved-samples/business-card -mindepth 1 -maxdepth 1 -type d \
+            ! -name '__pycache__' \
+            -name 'qr-*' -exec rm -rf {} + 2>/dev/null || true
+
+      - name: Run contract tests
+        working-directory: cardiff
+        run: python -m pytest tests/contract -q -p no:cacheprovider
+
+      - name: Run rendering tests
+        working-directory: cardiff
+        run: python -m pytest tests/rendering -q -p no:cacheprovider
+
+      - name: Run CLI tests
+        working-directory: cardiff
+        run: python -m pytest tests/cli -q -p no:cacheprovider

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build sdist and wheel
+        working-directory: cardiff
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: cardiff/dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/cardiff/pyproject.toml
+++ b/cardiff/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "cardiff"
+name = "cardiff-cli"
 version = "0.1.1"
 description = "Business cards as code."
 readme = "README.md"


### PR DESCRIPTION
This PR adds a CI workflow that runs tests during pull requests and releases. It test the library under Python 3.12 and 3.13 and in PR it only triggers when the base branch is on `rev` branch.

Included in this change is the rename of the publishing of package from `cardiff` to `cardiff-cli`