### PR TITLE
Update 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-Status: pre-alpha; `UNIT-001` is complete and the repository currently contains QR-directive rendering plus deterministic/Unicode rendering clarification work.
+Status: pre-alpha; `UNIT-001` is complete and the repository currently contains QR-directive rendering, deterministic/Unicode rendering clarification work, and normalized reference-evidence comparison.
+
+## v0.1.4
+
+### Added or Changed
+- Advanced the root public docs and requirements snapshot from `v0.1.3` to `v0.1.4`, including the current README status line and versioned-doc references.
+- Replaced ignored-environment-path setup examples in `README.md` with a generic `venv` example so the public quickstart no longer references ignored local environment paths.
+- Normalized render evidence so manifest fingerprints come from parsed manifest JSON and request fingerprints come from canonical request payloads without source metadata, which keeps approved evidence portable across checkout paths and line endings.
+- Added rendering determinism coverage that would fail if source metadata or manifest line endings start affecting normalized evidence again.
+- Refreshed `cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json` to the new normalized manifest/request fingerprints and restored the CLI reference-comparison path to exit code `0`.
+- Updated `cardiff/docs/render-pipeline.md`, `cardiff/docs/cli-quickstart.md`, `CONTRIBUTING.md`, and `REQUIREMENTS.md` to document the normalized evidence contract and current verification baseline.
+- Added `docs/version-0-1-4-docs.md` with the detailed release notes for this evidence-portability and root-doc alignment update.
+- Verified the targeted suite baseline for the current repo state: `tests/contract` passes (`9`), `tests/rendering` passes (`23`), and `tests/cli` passes (`14`).
+
+### For Deletion
+- `cardiff/tests/fixtures/approved-samples/business-card/.cardiff-qr/` generated QR work directory from non-deterministic rendering runs.
+- `cardiff/tests/fixtures/approved-samples/business-card/_directive-work/` generated QR directive test work directory.
+- `cardiff/tests/fixtures/approved-samples/business-card/cardiff-qr-*/` inaccessible temporary QR directories left behind by earlier runs.
+- `cardiff/pytest-cache-files-*/` temporary pytest cache directories that are currently permission-denied in this workspace.
+- `tmphk9u2kf5/` orphaned temporary root directory.
 
 ## v0.1.3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,8 @@ Contributions should stay tightly aligned with the approved roadmap instead of j
 - If you change the request contract, update `cardiff/docs/validation-contract.md` and the relevant tests in `cardiff/tests/contract/`.
 - If you change template resolution, rendering behavior, or QR directive preprocessing, update `cardiff/docs/render-pipeline.md` and the relevant tests in `cardiff/tests/rendering/`, including `test_directives.py` when directive or vCard behavior changes.
 - If you change CLI behavior, entrypoint wiring, status payloads, or exit-code semantics, update `cardiff/docs/cli-quickstart.md` and the relevant tests in `cardiff/tests/cli/`.
-- If you change the approved sample request, template manifest, deterministic render behavior, or any fingerprint-bearing artifact, refresh `cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json` and call that out in your pull request.
+- If you change the approved sample request, template manifest semantics, deterministic render behavior, or any fingerprint-bearing artifact, refresh `cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json` and call that out in your pull request.
+- Do not refresh reference evidence for path-only or line-ending-only checkout differences; the normalized evidence fingerprints are expected to stay stable across those environment details.
 - Do not include generated Python cache files, bytecode, or editable-install metadata in a contribution.
 - Do not commit temporary QR work directories or generated directive scratch space from `cardiff/tests/fixtures/approved-samples/business-card/`.
 - Make sure your work follows `CODE_OF_CONDUCT.md` and `SECURITY.md`.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
   </p>
 
   <p align="center">
-    Version: <code>v0.1.3</code><br>
-    Status: pre-alpha; <code>UNIT-001</code> is complete and the checked-in repo now includes QR-directive rendering support, expanded rendering coverage, and explicit Unicode-safe local rendering guidance.
+    Version: <code>v0.1.4</code><br>
+    Status: pre-alpha; <code>UNIT-001</code> is complete and the checked-in repo now includes QR-directive rendering support, explicit Unicode-safe local rendering guidance, and stable normalized-evidence comparison.
     <br />
     <a href="REQUIREMENTS.md"><strong>Explore the docs »</strong></a>
     <br />
@@ -173,14 +173,14 @@ Current commands:
 3. Create and activate a virtual environment:
 
    ```powershell
-   python -m venv .venv
-   .\.venv\Scripts\Activate.ps1
+   python -m venv venv
+   .\venv\Scripts\Activate.ps1
    ```
 
    If you are using `bash` or `zsh` instead of PowerShell:
 
    ```bash
-   source .venv/bin/activate
+   source venv/bin/activate
    ```
 
 4. Install the package and test dependencies:
@@ -213,15 +213,21 @@ Current commands:
 
 Expected current result:
 
-- 8 contract tests pass
-- 21 rendering tests pass
-- 11 of 12 CLI tests pass; the stored `reference-evidence.json` currently needs refresh, so the reference-comparison path is expected to return exit code `4`
+- 9 contract tests pass
+- 23 rendering tests pass
+- 14 CLI tests pass
 
 Optional reference-comparison check:
 
 ```powershell
 python -m cardiff render tests/fixtures/requests/valid-request.yaml --approved-asset-root tests/fixtures/approved-assets --output tests/fixtures/approved-samples/business-card/determinism-output.pdf --deterministic --reference-evidence tests/fixtures/approved-samples/business-card/reference-evidence.json
 ```
+
+Expected optional result:
+
+- the render succeeds
+- the reference comparison returns exit code `0`
+- the normalized manifest and canonical request fingerprints remain stable across checkout path and line-ending differences
 
 Current repo note: broad collection with `python -m pytest tests -q -p no:cacheprovider` can also fail until temporary QR work directories under `cardiff/tests/fixtures/approved-samples/business-card/` are cleaned.
 
@@ -263,6 +269,7 @@ cardiff/
     version-0-1-1-docs.md
     version-0-1-2-docs.md
     version-0-1-3-docs.md
+    version-0-1-4-docs.md
   learn/
     unit-001-bolt-001a-study-guide.md
   README.md
@@ -301,7 +308,7 @@ Start with these project artifacts:
 - `cardiff/docs/render-pipeline.md` for the shared render pipeline and adapter behavior
 - `cardiff/docs/cli-quickstart.md` for the current CLI workflow and exit-code contract
 - `learn/unit-001-bolt-001a-study-guide.md` for the guided walkthrough of the contract foundation
-- `docs/version-0-1-3-docs.md` for the current documentation-release notes beyond this README and changelog
+- `docs/version-0-1-4-docs.md` for the current documentation-release notes beyond this README and changelog
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # Requirements
 
-Status: pre-alpha public requirements snapshot for `v0.1.1`.
+Status: pre-alpha public requirements snapshot for `v0.1.4`.
 
 ## Objective
 
@@ -16,6 +16,7 @@ The current public MVP includes:
 - a shared render pipeline with deterministic evidence output
 - CLI `validate` and `render` commands
 - structured JSON status output and optional reference-evidence comparison
+- normalized manifest/request evidence that stays stable across checkout path and line-ending differences
 
 ## Acceptance Baseline
 
@@ -23,6 +24,7 @@ The current public MVP includes:
 - The approved `business-card` template renders to a requested PDF path.
 - CLI `validate` and `render` return actionable structured results with non-zero exits on failure.
 - Deterministic runs can compare normalized evidence against the approved reference record.
+- Reference-evidence comparison remains stable across equivalent checkout paths and line-ending differences.
 
 ## Recorded Verification
 
@@ -31,22 +33,20 @@ cd cardiff
 python -m pytest tests/contract -q -p no:cacheprovider
 python -m pytest tests/rendering -q -p no:cacheprovider
 python -m pytest tests/cli -q -p no:cacheprovider
-python -m pytest tests -q -p no:cacheprovider
 ```
 
 Expected result:
 
-- 8 contract tests pass
-- 5 rendering tests pass
-- 6 CLI tests pass
-- 19 total tests pass
+- 9 contract tests pass
+- 23 rendering tests pass
+- 14 CLI tests pass
 
 ## Public Source Files
 
 - `cardiff/docs/validation-contract.md`
 - `cardiff/docs/render-pipeline.md`
 - `cardiff/docs/cli-quickstart.md`
-- `docs/version-0-1-1-docs.md`
+- `docs/version-0-1-4-docs.md`
 - `learn/unit-001-bolt-001a-study-guide.md`
 
 ## Next Units

--- a/cardiff/docs/cli-quickstart.md
+++ b/cardiff/docs/cli-quickstart.md
@@ -35,6 +35,8 @@ python -m cardiff render tests/fixtures/requests/valid-request.yaml --approved-a
 
 When the current normalized render evidence matches the approved reference JSON, the command returns exit code `0`. If the PDF renders successfully but the normalized evidence differs, the command returns exit code `4` and reports the mismatched fields in `reference_comparison`.
 
+The reference-evidence comparison normalizes the template manifest and the canonical request payload before hashing, so the approved record stays portable across checkout path and line-ending differences.
+
 ## Exit Codes
 
 - `0`: command succeeded

--- a/cardiff/docs/render-pipeline.md
+++ b/cardiff/docs/render-pipeline.md
@@ -62,8 +62,8 @@ assert render_result.succeeded
 
 The normalized evidence record captures:
 
-- manifest fingerprint
-- canonical request fingerprint
+- normalized manifest fingerprint from parsed manifest JSON instead of raw checkout bytes
+- canonical request fingerprint from the sanitized request payload without source path or source-format metadata
 - rendered TeX fingerprint
 - PDF fingerprint
 - adapter runtime name and version

--- a/cardiff/src/cardiff/contract/validation.py
+++ b/cardiff/src/cardiff/contract/validation.py
@@ -224,6 +224,8 @@ from pathlib import Path
 import re
 from urllib.parse import urlparse
 
+from cardiff.paths import normalize_approved_asset_roots
+
 from .errors import ValidationCode, ValidationOutcome
 from .models import (
     AssetReference,
@@ -268,7 +270,7 @@ def validate_render_request(
     """Validate a parsed mapping and return a sanitized canonical request."""
 
     issues: list[ValidationIssue] = []
-    approved_roots = tuple(Path(root) for root in (approved_asset_roots or (Path("assets"),)))
+    approved_roots = normalize_approved_asset_roots(tuple(approved_asset_roots or ()))
 
     if not isinstance(payload, Mapping):
         issues.append(
@@ -367,6 +369,7 @@ def validate_asset_reference(
 
     slot = asset_reference.slot
     candidate = asset_reference.path
+    resolved_roots = normalize_approved_asset_roots(tuple(approved_roots))
 
     if slot not in ASSET_SLOTS:
         return _finalize_issues(
@@ -394,7 +397,7 @@ def validate_asset_reference(
     asset_path = Path(candidate)
     if asset_path.is_absolute():
         normalized = asset_path.resolve()
-        if not any(normalized.is_relative_to(Path(root).resolve()) for root in approved_roots):
+        if not any(normalized.is_relative_to(root) for root in resolved_roots):
             return _finalize_issues(
                 [
                     ValidationIssue(
@@ -405,6 +408,16 @@ def validate_asset_reference(
                 ]
             )
     else:
+        if not resolved_roots:
+            return _finalize_issues(
+                [
+                    ValidationIssue(
+                        code=ValidationCode.INVALID_ASSET_PATH,
+                        field=f"assets.{slot}",
+                        message="relative asset paths require at least one approved root",
+                    )
+                ]
+            )
         if ".." in asset_path.parts:
             return _finalize_issues(
                 [

--- a/cardiff/src/cardiff/paths.py
+++ b/cardiff/src/cardiff/paths.py
@@ -1,0 +1,13 @@
+"""Shared filesystem path helpers for Cardiff."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def normalize_approved_asset_roots(
+    approved_asset_roots: tuple[str | Path, ...] | None,
+) -> tuple[Path, ...]:
+    """Resolve approved asset roots into a canonical tuple of absolute paths."""
+
+    return tuple(Path(root).resolve() for root in (approved_asset_roots or ()))

--- a/cardiff/src/cardiff/rendering/pipeline.py
+++ b/cardiff/src/cardiff/rendering/pipeline.py
@@ -119,13 +119,14 @@ def render_request_to_pdf(
                 "adapter reported success but did not produce a non-empty PDF artifact",
             )
 
+        # Keep evidence stable across equivalent checkouts and input transport details.
         evidence = NormalizedRenderEvidence(
             template_id=template_id,
-            manifest_fingerprint=_sha256_bytes(
-                resolved_template.manifest_path.read_bytes()
+            manifest_fingerprint=_sha256_text(
+                _canonical_json_file_text(resolved_template.manifest_path)
             ),
             request_fingerprint=_sha256_text(
-                json.dumps(render_request.to_dict(include_source=True), sort_keys=True)
+                _canonical_json_text(render_request.to_dict())
             ),
             tex_fingerprint=_sha256_text(evidence_tex),
             pdf_fingerprint=_sha256_bytes(
@@ -211,6 +212,26 @@ def _build_preview_lines(
 
 def _sha256_text(value: str) -> str:
     return _sha256_bytes(value.encode("utf-8"))
+
+
+def _canonical_json_file_text(path: Path) -> str:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RenderingError(
+            RenderFailureClass.TEMPLATE_MANIFEST_INVALID,
+            f"failed to normalize template manifest '{path.as_posix()}': {error}",
+        ) from error
+    return _canonical_json_text(payload)
+
+
+def _canonical_json_text(payload: object) -> str:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
 
 
 def _sha256_bytes(value: bytes) -> str:

--- a/cardiff/src/cardiff/rendering/templates.py
+++ b/cardiff/src/cardiff/rendering/templates.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from cardiff.contract.models import RenderRequest, TemplateSelection
+from cardiff.paths import normalize_approved_asset_roots
 
 from .models import (
     RenderFailureClass,
@@ -82,7 +83,7 @@ def resolve_asset_paths(
 ) -> dict[str, Path]:
     """Resolve request asset references against approved roots and template rules."""
 
-    approved_roots = tuple(Path(root).resolve() for root in (approved_asset_roots or ()))
+    approved_roots = normalize_approved_asset_roots(approved_asset_roots)
     resolved_assets: dict[str, Path] = {}
 
     expected_slots = tuple(dict.fromkeys((*resolved_template.descriptor.required_asset_slots, *resolved_template.descriptor.optional_asset_slots)))

--- a/cardiff/tests/cli/test_cli.py
+++ b/cardiff/tests/cli/test_cli.py
@@ -286,6 +286,25 @@ def test_validate_command_returns_structured_issues_for_invalid_request():
     assert 'Validation rejected' in stderr
 
 
+def test_validate_command_rejects_relative_assets_without_approved_roots():
+    exit_code, payload, stderr = _run_cli(
+        [
+            'validate',
+            VALID_REQUEST.as_posix(),
+        ]
+    )
+
+    assert exit_code == 1
+    assert payload['command'] == 'validate'
+    assert payload['status'] == 'rejected'
+    assert payload['template_id'] == 'business-card'
+    assert payload['exit_code'] == 1
+    assert payload['issue_count'] == 1
+    assert payload['issues'][0]['code'] == 'invalid_asset_path'
+    assert payload['issues'][0]['field'] == 'assets.logo'
+    assert 'Validation rejected' in stderr
+
+
 def test_render_command_writes_the_requested_pdf_and_reports_runtime_metadata():
     exit_code, payload, stderr = _run_cli(
         [
@@ -350,6 +369,30 @@ def test_render_command_stops_when_validation_fails():
     assert payload['command'] == 'render'
     assert payload['status'] == 'rejected'
     assert payload['failure_stage'] == 'validation'
+    assert not INVALID_OUTPUT_PATH.exists()
+    assert 'failed validation' in stderr
+
+
+def test_render_command_rejects_relative_assets_without_approved_roots():
+    assert not INVALID_OUTPUT_PATH.exists()
+
+    exit_code, payload, stderr = _run_cli(
+        [
+            'render',
+            VALID_REQUEST.as_posix(),
+            '--output',
+            INVALID_OUTPUT_PATH.as_posix(),
+            '--deterministic',
+        ]
+    )
+
+    assert exit_code == 1
+    assert payload['command'] == 'render'
+    assert payload['status'] == 'rejected'
+    assert payload['failure_stage'] == 'validation'
+    assert payload['issue_count'] == 1
+    assert payload['issues'][0]['code'] == 'invalid_asset_path'
+    assert payload['issues'][0]['field'] == 'assets.logo'
     assert not INVALID_OUTPUT_PATH.exists()
     assert 'failed validation' in stderr
 

--- a/cardiff/tests/contract/test_validation.py
+++ b/cardiff/tests/contract/test_validation.py
@@ -310,3 +310,27 @@ template:
         "template.options.accent_hex",
         "template.options.include_qr",
     ]
+
+
+def test_relative_asset_paths_are_rejected_without_approved_roots():
+    payload = """
+identity:
+  full_name: "Ada Lovelace"
+  role: "Engineer"
+  email: "ada@example.com"
+template:
+  id: business-card
+assets:
+  logo: "brand/logo.png"
+"""
+
+    result = load_and_validate_request(
+        payload,
+        source_name="invalid.yaml",
+    )
+
+    assert result.outcome == ValidationOutcome.REJECTED
+    assert result.request is None
+    assert len(result.issues) == 1
+    assert result.issues[0].code == ValidationCode.INVALID_ASSET_PATH
+    assert result.issues[0].field == "assets.logo"

--- a/cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json
+++ b/cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json
@@ -1,7 +1,7 @@
 {
   "template_id": "business-card",
-  "manifest_fingerprint": "eb182c553dec2a88f24dc52df2b8745170e0ebfe8f09bec3e2edecb8cc5fb498",
-  "request_fingerprint": "5f17d60337facebf5c43813e984c060230572c9e36eb5dc23dda533391a8feea",
+  "manifest_fingerprint": "a897785f82fa4aa02e71850cde9371b6185fddca8764dce3798aa10f537bf95c",
+  "request_fingerprint": "77fd138ff53b73180192ebc8c1b27debc4e283b94eba6e0a8cf898fdc229b869",
   "tex_fingerprint": "9994df901f3f8055b1016496bb0bb98bff907cc65760413080918c672091dfc3",
   "pdf_fingerprint": "89eb5b2f53a4a2eaa410c3c448c59ca749022f7bc83b181e62e9f0927b853567",
   "runtime_name": "deterministic-tex-adapter",

--- a/cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json
+++ b/cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json
@@ -1,7 +1,7 @@
 {
   "template_id": "business-card",
   "manifest_fingerprint": "eb182c553dec2a88f24dc52df2b8745170e0ebfe8f09bec3e2edecb8cc5fb498",
-  "request_fingerprint": "3f26c4b5b1ac75792a7693a934be54291b9e543acb7e58041d0d67c8d50b2e58",
+  "request_fingerprint": "5f17d60337facebf5c43813e984c060230572c9e36eb5dc23dda533391a8feea",
   "tex_fingerprint": "9994df901f3f8055b1016496bb0bb98bff907cc65760413080918c672091dfc3",
   "pdf_fingerprint": "89eb5b2f53a4a2eaa410c3c448c59ca749022f7bc83b181e62e9f0927b853567",
   "runtime_name": "deterministic-tex-adapter",

--- a/cardiff/tests/rendering/test_determinism.py
+++ b/cardiff/tests/rendering/test_determinism.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 from cardiff.contract import load_and_validate_request
 from cardiff.contract.errors import ValidationOutcome
-from cardiff.rendering import DeterministicTeXAdapter, RenderStatus, render_request_to_pdf
+from cardiff.rendering import (
+    DeterministicTeXAdapter,
+    RenderStatus,
+    render_request_to_pdf,
+    resolve_template,
+)
 
 FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures"
 APPROVED_ASSETS = FIXTURES_ROOT / "approved-assets"
@@ -40,3 +47,76 @@ def test_repeated_runs_produce_matching_normalized_evidence():
         evidence_payloads.append(result.evidence.to_dict())
 
     assert evidence_payloads[0] == evidence_payloads[1] == evidence_payloads[2]
+
+
+def test_request_fingerprint_ignores_source_metadata():
+    request = _load_request()
+    output_path = APPROVED_SAMPLES / "determinism-output.pdf"
+    adapter = DeterministicTeXAdapter()
+    alternate_source_request = replace(
+        request,
+        source_name="C:/elsewhere/valid-request.json",
+        source_format="json",
+    )
+
+    baseline = render_request_to_pdf(
+        request,
+        output_path,
+        approved_asset_roots=(APPROVED_ASSETS,),
+        tex_adapter=adapter,
+    )
+    variant = render_request_to_pdf(
+        alternate_source_request,
+        output_path,
+        approved_asset_roots=(APPROVED_ASSETS,),
+        tex_adapter=adapter,
+    )
+
+    assert baseline.status == RenderStatus.SUCCEEDED
+    assert variant.status == RenderStatus.SUCCEEDED
+    assert baseline.evidence is not None
+    assert variant.evidence is not None
+    assert baseline.evidence.to_dict() == variant.evidence.to_dict()
+
+
+def test_manifest_fingerprint_ignores_line_ending_differences():
+    request = _load_request()
+    output_path = APPROVED_SAMPLES / "determinism-output.pdf"
+    adapter = DeterministicTeXAdapter()
+    resolved_template = resolve_template(request.template)
+    original_bytes = resolved_template.manifest_path.read_bytes()
+    newline = "\r\n" if b"\r\n" not in original_bytes else "\n"
+    manifest_text = original_bytes.decode("utf-8").replace("\r\n", "\n")
+    alternate_manifest_text = manifest_text.replace("\n", newline)
+    alternate_manifest_bytes = alternate_manifest_text.encode("utf-8")
+    assert alternate_manifest_bytes != original_bytes
+    alternate_manifest_path = Mock()
+    alternate_manifest_path.read_text.return_value = alternate_manifest_text
+    alternate_manifest_path.read_bytes.return_value = alternate_manifest_bytes
+    alternate_manifest_path.as_posix.return_value = "virtual/manifest.json"
+
+    baseline = render_request_to_pdf(
+        request,
+        output_path,
+        approved_asset_roots=(APPROVED_ASSETS,),
+        tex_adapter=adapter,
+    )
+    with patch(
+        "cardiff.rendering.pipeline.resolve_template",
+        return_value=replace(
+            resolved_template,
+            manifest_path=alternate_manifest_path,
+        ),
+    ):
+        variant = render_request_to_pdf(
+            request,
+            output_path,
+            approved_asset_roots=(APPROVED_ASSETS,),
+            tex_adapter=adapter,
+        )
+
+    assert baseline.status == RenderStatus.SUCCEEDED
+    assert variant.status == RenderStatus.SUCCEEDED
+    assert baseline.evidence is not None
+    assert variant.evidence is not None
+    assert baseline.evidence.to_dict() == variant.evidence.to_dict()

--- a/docs/version-0-1-4-docs.md
+++ b/docs/version-0-1-4-docs.md
@@ -1,0 +1,153 @@
+# Version 0.1.4 Documentation Release Notes
+
+## Document Metadata
+
+- **Version:** v0.1.4
+- **Release Date:** 2026-03-23
+- **Status:** pre-alpha
+- **Associated Unit:** UNIT-001 (complete), normalized evidence portability
+
+---
+
+## Executive Summary
+
+Version 0.1.4 is a focused reproducibility and public-doc alignment release.
+The main behavior change is that approved reference-evidence comparison is now stable across equivalent checkouts instead of drifting on path-only or line-ending-only differences.
+
+This release does five things:
+
+1. normalizes manifest fingerprints from parsed manifest JSON instead of raw checked-out bytes,
+2. normalizes request fingerprints from the canonical request payload without source metadata,
+3. adds regression coverage that fails if checkout path or line-ending details leak back into approved evidence,
+4. refreshes the approved reference-evidence record and restores the CLI comparison path to exit code `0`,
+5. advances the root public docs to `v0.1.4`, including a generic `venv` quickstart example and an updated requirements snapshot.
+
+---
+
+## What Changed from v0.1.3
+
+### Root Release Markers And Public Doc Alignment
+
+Files involved:
+
+- `README.md`
+- `CHANGELOG.md`
+- `REQUIREMENTS.md`
+- `docs/version-0-1-4-docs.md`
+
+The root public docs now describe the current repo state as `v0.1.4`.
+This release keeps the existing `v0.1.3` record intact and adds a new versioned note for the normalized-evidence change set.
+
+The root quickstart in `README.md` also now uses a generic `venv` example instead of an ignored local-environment path name.
+That keeps the public documentation aligned with the repo rule against surfacing ignored local workflow paths in the published root docs.
+
+### Reference Evidence Is Now Portable Across Equivalent Checkouts
+
+Files involved:
+
+- `cardiff/src/cardiff/rendering/pipeline.py`
+- `cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json`
+
+The render pipeline now normalizes evidence inputs before hashing them:
+
+- the manifest fingerprint is derived from canonicalized parsed JSON instead of raw manifest file bytes,
+- the request fingerprint is derived from `render_request.to_dict()` instead of a payload that includes source-path metadata.
+
+This matters because the prior behavior could report a false reference mismatch when:
+
+- the same manifest was checked out with different line endings,
+- the same request was loaded from a different absolute path,
+- the approved evidence file was refreshed on one machine and compared on another.
+
+The approved `reference-evidence.json` fixture was refreshed to the normalized manifest and request fingerprints produced by the new behavior.
+
+### Regression Coverage For Future Regressions
+
+Files involved:
+
+- `cardiff/tests/rendering/test_determinism.py`
+
+Two determinism regressions now protect this behavior:
+
+1. `test_request_fingerprint_ignores_source_metadata()` verifies that changing `source_name` and `source_format` does not change normalized evidence.
+2. `test_manifest_fingerprint_ignores_line_ending_differences()` verifies that equivalent manifest JSON with different line endings produces the same evidence payload.
+
+These tests make the original failure mode much harder to reintroduce without an explicit test failure.
+
+### Public Docs And Contributor Guidance
+
+Files involved:
+
+- `cardiff/docs/render-pipeline.md`
+- `cardiff/docs/cli-quickstart.md`
+- `CONTRIBUTING.md`
+
+The supporting docs now explain the normalized evidence contract directly:
+
+- `cardiff/docs/render-pipeline.md` explains what the manifest and request fingerprints are actually derived from,
+- `cardiff/docs/cli-quickstart.md` now states that the approved comparison is portable across checkout path and line-ending differences,
+- `CONTRIBUTING.md` now tells contributors not to refresh approved evidence for path-only or line-ending-only checkout differences.
+
+That contributor note is important because it turns the bug fix into a maintained workflow rule instead of leaving it as an implementation detail buried in the pipeline.
+
+### Current Verification Snapshot
+
+Commands run for this release:
+
+```powershell
+cd d:\Programming\Repositories\cardiff\cardiff
+python -m pytest tests/contract -q -p no:cacheprovider
+python -m pytest tests/rendering -q -p no:cacheprovider
+python -m pytest tests/cli -q -p no:cacheprovider
+```
+
+Observed results:
+
+- `tests/contract`: `9 passed`
+- `tests/rendering`: `23 passed`
+- `tests/cli`: `14 passed`
+
+The optional CLI reference-comparison path now succeeds again when run against the approved request, approved asset root, deterministic adapter, and refreshed `reference-evidence.json`.
+
+### Cleanup Candidates Carried Forward
+
+These directories still exist in the workspace and should be removed manually by the user when appropriate:
+
+- `cardiff/tests/fixtures/approved-samples/business-card/.cardiff-qr/`
+- `cardiff/tests/fixtures/approved-samples/business-card/_directive-work/`
+- `cardiff/tests/fixtures/approved-samples/business-card/cardiff-qr-*/`
+- `cardiff/pytest-cache-files-*/`
+- `tmphk9u2kf5/`
+
+### Other Markdown Files
+
+No changes were required in:
+
+- `SECURITY.md`
+- `CODE_OF_CONDUCT.md`
+
+Reason:
+
+This release changes render evidence behavior, contributor workflow guidance, and public documentation, but it does not alter vulnerability disclosure policy or community conduct rules.
+
+---
+
+## Files Touched in This Release
+
+- `README.md`
+- `CHANGELOG.md`
+- `REQUIREMENTS.md`
+- `docs/version-0-1-4-docs.md`
+- `cardiff/docs/render-pipeline.md`
+- `cardiff/docs/cli-quickstart.md`
+- `CONTRIBUTING.md`
+- `cardiff/src/cardiff/rendering/pipeline.py`
+- `cardiff/tests/rendering/test_determinism.py`
+- `cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json`
+
+---
+
+## Next Steps
+
+1. Decide whether deterministic mode should remain strictly ASCII-only or gain a separate transliteration or escaping strategy for developer previews.
+2. Clean the lingering temporary QR and pytest-cache directories before relying on broad test collection.


### PR DESCRIPTION
# Version 0.1.4 Documentation Release Notes

## Document Metadata

- **Version:** v0.1.4
- **Release Date:** 2026-03-23
- **Status:** pre-alpha
- **Associated Unit:** UNIT-001 (complete), normalized evidence portability

---

## Executive Summary

Version 0.1.4 is a focused reproducibility and public-doc alignment release.
The main behavior change is that approved reference-evidence comparison is now stable across equivalent checkouts instead of drifting on path-only or line-ending-only differences.

This release does five things:

1. normalizes manifest fingerprints from parsed manifest JSON instead of raw checked-out bytes,
2. normalizes request fingerprints from the canonical request payload without source metadata,
3. adds regression coverage that fails if checkout path or line-ending details leak back into approved evidence,
4. refreshes the approved reference-evidence record and restores the CLI comparison path to exit code `0`,
5. advances the root public docs to `v0.1.4`, including a generic `venv` quickstart example and an updated requirements snapshot.

---

## What Changed from v0.1.3

### Root Release Markers And Public Doc Alignment

Files involved:

- `README.md`
- `CHANGELOG.md`
- `REQUIREMENTS.md`
- `docs/version-0-1-4-docs.md`

The root public docs now describe the current repo state as `v0.1.4`.
This release keeps the existing `v0.1.3` record intact and adds a new versioned note for the normalized-evidence change set.

The root quickstart in `README.md` also now uses a generic `venv` example instead of an ignored local-environment path name.
That keeps the public documentation aligned with the repo rule against surfacing ignored local workflow paths in the published root docs.

### Reference Evidence Is Now Portable Across Equivalent Checkouts

Files involved:

- `cardiff/src/cardiff/rendering/pipeline.py`
- `cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json`

The render pipeline now normalizes evidence inputs before hashing them:

- the manifest fingerprint is derived from canonicalized parsed JSON instead of raw manifest file bytes,
- the request fingerprint is derived from `render_request.to_dict()` instead of a payload that includes source-path metadata.

This matters because the prior behavior could report a false reference mismatch when:

- the same manifest was checked out with different line endings,
- the same request was loaded from a different absolute path,
- the approved evidence file was refreshed on one machine and compared on another.

The approved `reference-evidence.json` fixture was refreshed to the normalized manifest and request fingerprints produced by the new behavior.

### Regression Coverage For Future Regressions

Files involved:

- `cardiff/tests/rendering/test_determinism.py`

Two determinism regressions now protect this behavior:

1. `test_request_fingerprint_ignores_source_metadata()` verifies that changing `source_name` and `source_format` does not change normalized evidence.
2. `test_manifest_fingerprint_ignores_line_ending_differences()` verifies that equivalent manifest JSON with different line endings produces the same evidence payload.

These tests make the original failure mode much harder to reintroduce without an explicit test failure.

### Public Docs And Contributor Guidance

Files involved:

- `cardiff/docs/render-pipeline.md`
- `cardiff/docs/cli-quickstart.md`
- `CONTRIBUTING.md`

The supporting docs now explain the normalized evidence contract directly:

- `cardiff/docs/render-pipeline.md` explains what the manifest and request fingerprints are actually derived from,
- `cardiff/docs/cli-quickstart.md` now states that the approved comparison is portable across checkout path and line-ending differences,
- `CONTRIBUTING.md` now tells contributors not to refresh approved evidence for path-only or line-ending-only checkout differences.

That contributor note is important because it turns the bug fix into a maintained workflow rule instead of leaving it as an implementation detail buried in the pipeline.

### Current Verification Snapshot

Commands run for this release:

```powershell
cd d:\Programming\Repositories\cardiff\cardiff
python -m pytest tests/contract -q -p no:cacheprovider
python -m pytest tests/rendering -q -p no:cacheprovider
python -m pytest tests/cli -q -p no:cacheprovider
```

Observed results:

- `tests/contract`: `9 passed`
- `tests/rendering`: `23 passed`
- `tests/cli`: `14 passed`

The optional CLI reference-comparison path now succeeds again when run against the approved request, approved asset root, deterministic adapter, and refreshed `reference-evidence.json`.

### Cleanup Candidates Carried Forward

These directories still exist in the workspace and should be removed manually by the user when appropriate:

- `cardiff/tests/fixtures/approved-samples/business-card/.cardiff-qr/`
- `cardiff/tests/fixtures/approved-samples/business-card/_directive-work/`
- `cardiff/tests/fixtures/approved-samples/business-card/cardiff-qr-*/`
- `cardiff/pytest-cache-files-*/`
- `tmphk9u2kf5/`

### Other Markdown Files

No changes were required in:

- `SECURITY.md`
- `CODE_OF_CONDUCT.md`

Reason:

This release changes render evidence behavior, contributor workflow guidance, and public documentation, but it does not alter vulnerability disclosure policy or community conduct rules.

---

## Files Touched in This Release

- `README.md`
- `CHANGELOG.md`
- `REQUIREMENTS.md`
- `docs/version-0-1-4-docs.md`
- `cardiff/docs/render-pipeline.md`
- `cardiff/docs/cli-quickstart.md`
- `CONTRIBUTING.md`
- `cardiff/src/cardiff/rendering/pipeline.py`
- `cardiff/tests/rendering/test_determinism.py`
- `cardiff/tests/fixtures/approved-samples/business-card/reference-evidence.json`

---

## Next Steps

1. Decide whether deterministic mode should remain strictly ASCII-only or gain a separate transliteration or escaping strategy for developer previews.
2. Clean the lingering temporary QR and pytest-cache directories before relying on broad test collection.
