### PR TITLE
feat: add gated GitHub Actions CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, rev]
   pull_request:
-    branches: [rev]
+    branches: [main, rev]
 
 permissions:
   contents: read
@@ -30,12 +30,18 @@ jobs:
         working-directory: cardiff
         run: pip install -e ".[dev]"
 
-      - name: Clean temporary QR work directories
+      - name: Clean transient test work directories
         working-directory: cardiff
         run: |
+          rm -rf \
+            tests/fixtures/approved-samples/business-card/.cardiff-qr \
+            tests/fixtures/approved-samples/business-card/_directive-work
           find tests/fixtures/approved-samples/business-card -mindepth 1 -maxdepth 1 -type d \
-            ! -name '__pycache__' \
-            -name 'qr-*' -exec rm -rf {} + 2>/dev/null || true
+            -name 'cardiff-qr-*' -exec rm -rf {} +
+          find tests/fixtures -mindepth 1 -maxdepth 1 -type d \
+            -name 'tmp*' -exec rm -rf {} +
+          find . -mindepth 1 -maxdepth 1 -type d \
+            \( -name 'pytest-cache-files-*' -o -name 'tmp*' \) -exec rm -rf {} +
 
       - name: Run contract tests
         working-directory: cardiff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,89 @@ permissions:
   contents: read
 
 jobs:
+  validate_release:
+    name: Validate release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      package-version: ${{ steps.project-version.outputs.package-version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - id: project-version
+        name: Read package version
+        working-directory: cardiff
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import tomllib
+
+          with open("pyproject.toml", "rb") as handle:
+              version = tomllib.load(handle)["project"]["version"]
+
+          print(f"package-version={version}")
+          PY
+
+      - name: Ensure tag matches package version
+        run: |
+          if [ "v${{ steps.project-version.outputs.package-version }}" != "${GITHUB_REF_NAME}" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match package version v${{ steps.project-version.outputs.package-version }}." >&2
+            exit 1
+          fi
+
+  test:
+    name: Release verification (Python ${{ matrix.python-version }})
+    needs: validate_release
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        working-directory: cardiff
+        run: pip install -e ".[dev]"
+
+      - name: Clean transient test work directories
+        working-directory: cardiff
+        run: |
+          rm -rf \
+            tests/fixtures/approved-samples/business-card/.cardiff-qr \
+            tests/fixtures/approved-samples/business-card/_directive-work
+          find tests/fixtures/approved-samples/business-card -mindepth 1 -maxdepth 1 -type d \
+            -name 'cardiff-qr-*' -exec rm -rf {} +
+          find tests/fixtures -mindepth 1 -maxdepth 1 -type d \
+            -name 'tmp*' -exec rm -rf {} +
+          find . -mindepth 1 -maxdepth 1 -type d \
+            \( -name 'pytest-cache-files-*' -o -name 'tmp*' \) -exec rm -rf {} +
+
+      - name: Run contract tests
+        working-directory: cardiff
+        run: python -m pytest tests/contract -q -p no:cacheprovider
+
+      - name: Run rendering tests
+        working-directory: cardiff
+        run: python -m pytest tests/rendering -q -p no:cacheprovider
+
+      - name: Run CLI tests
+        working-directory: cardiff
+        run: python -m pytest tests/cli -q -p no:cacheprovider
+
   build:
     name: Build distribution
+    needs: [validate_release, test]
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
-Status: pre-alpha; `UNIT-001` is complete and the repository currently contains QR-directive rendering, deterministic/Unicode rendering clarification work, normalized reference-evidence comparison, and fail-fast unknown-template-placeholder rejection.
+Status: pre-alpha; `UNIT-001` is complete and the repository currently contains QR-directive rendering, deterministic/Unicode rendering clarification work, normalized reference-evidence comparison, fail-fast unknown-template-placeholder rejection, and initial GitHub Actions validation/release automation.
+
+## v0.1.6
+
+### Added or Changed
+- Advanced the root public release markers from `v0.1.5` to `v0.1.6` in `README.md` and `REQUIREMENTS.md`.
+- Added `.github/workflows/ci.yml` so pushes and pull requests targeting `main` or `rev` now run the targeted contract, rendering, and CLI suites across Python `3.12` and `3.13`, with cleanup patterns that match Cardiff's actual transient test directories.
+- Added `.github/workflows/release.yml` so pushed `v*` tags now validate `cardiff/pyproject.toml` version metadata, rerun the targeted suites, build distributions, and publish only after those gates pass.
+- Updated `cardiff/pyproject.toml` so the distribution metadata now uses `cardiff-cli` and the in-tree package version is aligned to `0.1.6` while preserving the `cardiff` console entrypoint.
+- Updated `README.md`, `REQUIREMENTS.md`, and `CONTRIBUTING.md` so the public docs now reflect the current CI/release workflows, the `cardiff-cli` distribution name, and the fact that `main` and `rev` are both valid integration targets under the current automation.
+- Added `docs/version-0-1-6-docs.md` with the detailed release notes for this CI/release automation and metadata-alignment update.
+- Verified the targeted suite baseline for the current repo state: `tests/contract` passes (`9`), `tests/rendering` passes (`25`), and `tests/cli` passes (`14`).
+
+### For Deletion
+- `cardiff/tests/fixtures/approved-samples/business-card/.cardiff-qr/` generated QR work directory from non-deterministic rendering runs.
+- `cardiff/tests/fixtures/approved-samples/business-card/_directive-work/` generated QR directive test work directory.
+- `cardiff/tests/fixtures/approved-samples/business-card/cardiff-qr-*/` inaccessible temporary QR directories left behind by earlier runs.
+- `cardiff/tests/fixtures/tmp5jdz_7bl/` orphaned temporary test directory left behind by an earlier failed cleanup attempt.
+- `cardiff/tests/fixtures/tmpr9v8b8nh/` orphaned temporary test directory left behind by an earlier failed cleanup attempt.
+- `cardiff/pytest-cache-files-*/` temporary pytest cache directories that are currently permission-denied in this workspace.
+- `cardiff/tmpgremi45_/` orphaned temporary project-root directory left behind by an earlier failed cleanup attempt.
+- `cardiff/tmpn4v7ks5z/` orphaned temporary project-root directory left behind by an earlier failed cleanup attempt.
+- `tmphk9u2kf5/` orphaned temporary root directory.
 
 ## v0.1.5
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Thanks for contributing to Cardiff.
 
 Cardiff is now in an early pre-alpha implementation stage.
 `UNIT-001` is complete, the first CLI operator flow is in place, and the checked-in repo now also includes QR-directive rendering work.
+The current repo also includes initial GitHub Actions validation and release workflows, though the broader `UNIT-005` runtime packaging and deployment scope is still open.
 Contributions should stay tightly aligned with the approved roadmap instead of jumping ahead with disconnected features.
 
 ## Before You Start
@@ -38,11 +39,11 @@ Strong contributions usually:
 ## Workflow
 
 1. Fork the repository.
-2. Create a short-lived branch from `rev`.
+2. Create a short-lived branch from the integration branch you intend to target (`main` or `rev`).
 3. Name the branch in kebab-case and start it with the relevant Conventional Commit type.
 4. Make the smallest cohesive change that solves the problem.
 5. Update docs and tests when applicable.
-6. Open a pull request targeting `rev` with clear context and verification details.
+6. Open a pull request targeting that same integration branch with clear context and verification details.
 7. Delete the branch after the pull request is merged.
 
 Example branch name:
@@ -55,7 +56,8 @@ Branch policy notes:
 
 - Use short-lived branches only.
 - Keep one branch focused on one issue or cohesive change.
-- Sync `rev` before creating a new branch.
+- Sync the integration branch you plan to target before creating a new branch.
+- The current GitHub Actions validation flow runs on pushes and pull requests for both `main` and `rev`.
 
 ## Commit Messages
 
@@ -91,6 +93,7 @@ Each pull request should include:
 Prefer small pull requests over large mixed changes.
 If your work changes public behavior, update `README.md` and `CHANGELOG.md`.
 If your work changes the canonical contract or approved scope, update `REQUIREMENTS.md` and the affected public docs as well.
+If your work changes packaging or release automation, keep `.github/workflows/release.yml`, the package metadata in `cardiff/pyproject.toml`, and the intended `v*` release tag consistent.
 
 ## Verification Notes
 
@@ -103,6 +106,8 @@ python -m pytest tests/rendering -q -p no:cacheprovider
 python -m pytest tests/cli -q -p no:cacheprovider
 ```
 
+These are the same suites enforced by `.github/workflows/ci.yml` and rerun by `.github/workflows/release.yml`.
+
 The broad `python -m pytest tests -q -p no:cacheprovider` command can currently fail if temporary QR work directories or other stray temp directories are still present in the workspace.
 Clean those directories before relying on broad test collection.
 
@@ -111,6 +116,10 @@ Expected current result:
 - `tests/contract`: `9 passed`
 - `tests/rendering`: `25 passed`
 - `tests/cli`: `14 passed`
+
+Release automation note:
+
+- pushed `v*` release tags are expected to match the package version in `cardiff/pyproject.toml` exactly, for example `v0.1.6` -> `0.1.6`
 
 ## Review Standards
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
   </p>
 
   <p align="center">
-    Version: <code>v0.1.5</code><br>
-    Status: pre-alpha; <code>UNIT-001</code> is complete and the checked-in repo now includes QR-directive rendering support, explicit Unicode-safe local rendering guidance, stable normalized-evidence comparison, and fail-fast rejection of unknown template placeholders before PDF generation.
+    Version: <code>v0.1.6</code> public release line<br>
+    Status: pre-alpha; <code>UNIT-001</code> is complete and the current repo head now includes QR-directive rendering support, explicit Unicode-safe local rendering guidance, stable normalized-evidence comparison, fail-fast rejection of unknown template placeholders before PDF generation, and initial GitHub Actions validation/release workflows.
     <br />
     <a href="REQUIREMENTS.md"><strong>Explore the docs »</strong></a>
     <br />
@@ -102,7 +102,7 @@ The repository now contains a complete `UNIT-001` baseline under the nested Pyth
 
 What is in place today:
 
-- a Python package scaffold with setuptools metadata in `cardiff/pyproject.toml`
+- a Python package scaffold with setuptools metadata in `cardiff/pyproject.toml` for the `cardiff-cli` distribution
 - a public package surface in `cardiff/src/cardiff/`
 - a framework-agnostic contract kernel in `cardiff/src/cardiff/contract/`
 - a shared render pipeline in `cardiff/src/cardiff/rendering/`, including QR/vCard directive preprocessing in `directives.py`
@@ -111,6 +111,7 @@ What is in place today:
 - installed-package and source-checkout entry paths through `cardiff/src/cardiff/__main__.py` and `cardiff/cardiff.py`
 - deterministic local PDF generation for stable ASCII-only smoke checks plus a real `XeLaTeXAdapter` boundary for Unicode-safe runtime parity when `xelatex` is available
 - CLI, contract, and rendering tests and fixtures under `cardiff/tests/`, including directive-focused coverage in `cardiff/tests/rendering/test_directives.py`
+- GitHub Actions workflows under `.github/workflows/` for targeted validation on pushes and pull requests plus tag-gated release verification and distribution builds
 - implementation documentation in `cardiff/docs/validation-contract.md`, `cardiff/docs/render-pipeline.md`, and `cardiff/docs/cli-quickstart.md`
 - contributor-facing template guidance in `cardiff/docs/template-authoring.md`
 - stored approval artifacts in `cardiff/tests/fixtures/approved-samples/business-card/`
@@ -191,6 +192,8 @@ Current commands:
    python -m pip install -e ".[dev]"
    ```
 
+   This creates the local `cardiff` console command. The package metadata currently uses the distribution name `cardiff-cli`.
+
 5. Validate the approved sample request:
 
    ```powershell
@@ -219,6 +222,8 @@ Expected current result:
 - 25 rendering tests pass
 - 14 CLI tests pass
 
+These are also the targeted suites enforced by the current GitHub Actions CI and release workflows.
+
 Optional reference-comparison check:
 
 ```powershell
@@ -239,6 +244,10 @@ Current repo note: broad collection with `python -m pytest tests -q -p no:cachep
 
 ```text
 cardiff/
+  .github/
+    workflows/
+      ci.yml
+      release.yml
   cardiff/
     cardiff.py
     pyproject.toml
@@ -274,6 +283,7 @@ cardiff/
     version-0-1-3-docs.md
     version-0-1-4-docs.md
     version-0-1-5-docs.md
+    version-0-1-6-docs.md
   learn/
     unit-001-bolt-001a-study-guide.md
   README.md
@@ -295,7 +305,9 @@ cardiff/
 - [ ] `UNIT-002`: template quality and controlled customization
 - [ ] `UNIT-003`: CSV batch generation
 - [ ] `UNIT-004`: FastAPI service mode
-- [ ] `UNIT-005`: runtime packaging, CI, deployment, and ops readiness
+- [ ] `UNIT-005`: runtime packaging, broader CI, deployment, and ops readiness
+
+Initial GitHub Actions validation and release workflows are already in-tree, but the broader `UNIT-005` runtime packaging, deployment, and operational-readiness scope remains open.
 
 See the [open issues](https://github.com/zcalifornia-ph/cardiff/issues) for proposed features and known gaps.
 
@@ -312,8 +324,10 @@ Start with these project artifacts:
 - `cardiff/docs/render-pipeline.md` for the shared render pipeline and adapter behavior
 - `cardiff/docs/cli-quickstart.md` for the current CLI workflow and exit-code contract
 - `cardiff/docs/template-authoring.md` for the approved business-card template package rules and contributor-facing template expectations
+- `.github/workflows/ci.yml` for the current targeted validation matrix on pushes and pull requests
+- `.github/workflows/release.yml` for the current tag-gated release verification and publish flow
 - `learn/unit-001-bolt-001a-study-guide.md` for the guided walkthrough of the contract foundation
-- `docs/version-0-1-5-docs.md` for the latest checked-in versioned documentation-release notes beyond this README and changelog
+- `docs/version-0-1-6-docs.md` for the latest checked-in versioned documentation-release notes beyond this README and changelog
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -323,10 +337,10 @@ Contributions are welcome, especially around render quality, CLI ergonomics, bat
 See `CONTRIBUTING.md` for workflow expectations.
 
 1. Fork the repository.
-2. Create a short-lived branch from `rev`.
+2. Create a short-lived branch from the integration branch you intend to target (`main` or `rev`).
 3. Make the smallest cohesive change that solves the problem.
 4. Update docs and tests when applicable.
-5. Open a pull request targeting `rev` with clear context and verification details.
+5. Open a pull request targeting that same integration branch with clear context and verification details.
 6. Delete the short-lived branch after merge.
 
 ### Top Contributors

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # Requirements
 
-Status: pre-alpha public requirements snapshot for `v0.1.5`.
+Status: pre-alpha public requirements snapshot for `v0.1.6`.
 
 ## Objective
 
@@ -18,6 +18,8 @@ The current public MVP includes:
 - structured JSON status output and optional reference-evidence comparison
 - normalized manifest/request evidence that stays stable across checkout path and line-ending differences
 - fail-fast rejection of unknown template placeholders before PDF generation starts
+- initial GitHub Actions validation for pushes and pull requests plus tag-gated release verification before distribution publishing
+- package metadata aligned to the `cardiff-cli` distribution while preserving the `cardiff` console command
 
 ## Acceptance Baseline
 
@@ -27,6 +29,7 @@ The current public MVP includes:
 - Deterministic runs can compare normalized evidence against the approved reference record.
 - Reference-evidence comparison remains stable across equivalent checkout paths and line-ending differences.
 - Templates with unknown placeholders fail before PDF generation with a stable render failure class.
+- Tagged releases validate package-version metadata and rerun the targeted suites before building distributions or publishing.
 
 ## Recorded Verification
 
@@ -49,7 +52,10 @@ Expected result:
 - `cardiff/docs/render-pipeline.md`
 - `cardiff/docs/cli-quickstart.md`
 - `cardiff/docs/template-authoring.md`
-- `docs/version-0-1-5-docs.md`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `cardiff/pyproject.toml`
+- `docs/version-0-1-6-docs.md`
 - `learn/unit-001-bolt-001a-study-guide.md`
 
 ## Next Units
@@ -57,6 +63,6 @@ Expected result:
 - `UNIT-002`: template quality and controlled customization
 - `UNIT-003`: CSV batch generation
 - `UNIT-004`: FastAPI service mode
-- `UNIT-005`: runtime packaging, CI, deployment, and ops readiness
+- `UNIT-005`: runtime packaging, broader CI, deployment, and ops readiness
 
 This public snapshot intentionally keeps hidden planning and traceability files out of the root documentation surface.

--- a/cardiff/pyproject.toml
+++ b/cardiff/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cardiff-cli"
-version = "0.1.1"
+version = "0.1.6"
 description = "Business cards as code."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/docs/version-0-1-6-docs.md
+++ b/docs/version-0-1-6-docs.md
@@ -1,0 +1,173 @@
+# Version 0.1.6 Documentation Release Notes
+
+## Document Metadata
+
+- **Version:** v0.1.6
+- **Release Date:** 2026-03-24
+- **Status:** pre-alpha
+- **Associated Unit:** UNIT-001 (complete), initial CI/release automation and metadata alignment
+
+---
+
+## Executive Summary
+
+Version 0.1.6 is a release-engineering and documentation-alignment update.
+The main behavior change is that the repository now has initial GitHub Actions workflows that verify the real integration paths and prevent tagged releases from publishing unless version metadata and the targeted test suites agree.
+
+This release does five things:
+
+1. adds GitHub Actions CI coverage for pushes and pull requests targeting the current integration branches,
+2. reruns the targeted test baseline before tagged releases can build or publish distributions,
+3. rejects mismatched release tags before any publish step starts,
+4. aligns package metadata and public docs to `v0.1.6` and the `cardiff-cli` distribution name,
+5. records the latest verification baseline and current cleanup candidates.
+
+---
+
+## What Changed from v0.1.5
+
+### GitHub Actions CI Now Covers The Real Integration Paths
+
+Files involved:
+
+- `.github/workflows/ci.yml`
+
+The previous workflow draft only covered pull requests targeting `rev`.
+That left merges to `main` without protection, even though the repo's broader branching guidance was already mixed between `main` and `rev`.
+
+This release corrects that by:
+
+- running CI on pushes to both `main` and `rev`,
+- running pull-request validation for both `main` and `rev`,
+- keeping the targeted contract, rendering, and CLI suites on Python `3.12` and `3.13`.
+
+The goal is not to solve all of `UNIT-005`.
+It is to make the current repository automation actually cover the integration branches that contributors can use today.
+
+### Transient Test Cleanup Now Matches Cardiff's Real Workspace Artifacts
+
+Files involved:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+
+The original cleanup step removed `qr-*`, which does not match Cardiff's actual transient test directories.
+
+This release updates the cleanup behavior so the workflows now remove the directories the repo really accumulates before running tests, including:
+
+- `.cardiff-qr/`
+- `_directive-work/`
+- `cardiff-qr-*`
+- `tests/fixtures/tmp*`
+- project-root `pytest-cache-files-*`
+- project-root `tmp*`
+
+This matters because the current repo already documents that stray temporary directories can interfere with broader test collection.
+The workflow cleanup should therefore target the real artifacts, not an unrelated naming pattern.
+
+### Tagged Releases Now Fail Fast On Metadata Drift And Test Regressions
+
+Files involved:
+
+- `.github/workflows/release.yml`
+- `cardiff/pyproject.toml`
+
+The previous release workflow built and published on any `v*` tag without first proving that the tag matched package metadata or that the targeted verification baseline still passed.
+
+This release adds a gated release flow:
+
+- a metadata-validation job reads the package version from `cardiff/pyproject.toml`,
+- the workflow fails immediately if the pushed tag does not match that version,
+- the targeted contract, rendering, and CLI suites rerun across Python `3.12` and `3.13`,
+- distribution build runs only after metadata validation and tests succeed,
+- PyPI publish remains downstream of a successful build.
+
+This is still an initial automation slice, not a full deployment system.
+But it closes the most obvious gap: tags should not publish unverified or version-drifted artifacts.
+
+### Package Metadata And Public Docs Were Realigned
+
+Files involved:
+
+- `cardiff/pyproject.toml`
+- `README.md`
+- `REQUIREMENTS.md`
+- `CHANGELOG.md`
+- `CONTRIBUTING.md`
+- `docs/version-0-1-6-docs.md`
+
+The public root docs and package metadata now describe the same repo state.
+
+Specific alignment updates include:
+
+- `README.md` now points to `v0.1.6` and the latest versioned documentation note,
+- `REQUIREMENTS.md` now records the initial CI/release automation baseline and the `cardiff-cli` distribution naming,
+- `CHANGELOG.md` now records this work as the new `v0.1.6` release entry instead of leaving it as an `Unreleased` fragment,
+- `CONTRIBUTING.md` now keeps the release-tag example aligned to the current version line,
+- `cardiff/pyproject.toml` now uses version `0.1.6` while preserving the `cardiff` console command surface.
+
+This keeps the repo's public release markers, release workflow expectations, and package metadata from drifting apart again.
+
+### Current Verification Snapshot
+
+Commands run for the current repo state:
+
+```powershell
+cd d:\Programming\Repositories\cardiff\cardiff
+python -m pytest tests/contract -q -p no:cacheprovider
+python -m pytest tests/rendering -q -p no:cacheprovider
+python -m pytest tests/cli -q -p no:cacheprovider
+```
+
+Observed results:
+
+- `tests/contract`: `9 passed`
+- `tests/rendering`: `25 passed`
+- `tests/cli`: `14 passed`
+
+These are the same targeted suites now enforced by the checked-in CI and release workflows.
+
+### Cleanup Candidates Carried Forward
+
+These directories still exist in the workspace and should be removed manually by the user when appropriate:
+
+- `cardiff/tests/fixtures/approved-samples/business-card/.cardiff-qr/`
+- `cardiff/tests/fixtures/approved-samples/business-card/_directive-work/`
+- `cardiff/tests/fixtures/approved-samples/business-card/cardiff-qr-*/`
+- `cardiff/tests/fixtures/tmp5jdz_7bl/`
+- `cardiff/tests/fixtures/tmpr9v8b8nh/`
+- `cardiff/pytest-cache-files-*/`
+- `cardiff/tmpgremi45_/`
+- `cardiff/tmpn4v7ks5z/`
+- `tmphk9u2kf5/`
+
+### Other Markdown Files
+
+No changes were required in:
+
+- `SECURITY.md`
+- `CODE_OF_CONDUCT.md`
+
+Reason:
+
+This release changes repository automation, package metadata alignment, and contributor/public documentation, but it does not alter vulnerability disclosure policy or community conduct rules.
+
+---
+
+## Files Touched in This Release
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `cardiff/pyproject.toml`
+- `README.md`
+- `REQUIREMENTS.md`
+- `CHANGELOG.md`
+- `CONTRIBUTING.md`
+- `docs/version-0-1-6-docs.md`
+
+---
+
+## Next Steps
+
+1. Decide whether the repository should continue supporting both `main` and `rev` as integration targets or fully normalize on one protected trunk path.
+2. Expand `UNIT-005` beyond the initial workflow baseline with broader collection safety, release-process documentation, deployment packaging, and operations readiness artifacts.


### PR DESCRIPTION
- added .github/workflows/ci.yml so pushes and pull requests targeting main or rev now run the targeted contract, rendering, and CLI suites across Python 3.12 and 3.13, including cleanup for Cardiff's actual transient test directories.

- added .github/workflows/release.yml so v* tags now validate package version metadata, rerun the targeted suites, build distributions, and only publish after those checks pass.

- aligned cardiff/pyproject.toml to version 0.1.6 while preserving the cardiff console entrypoint under the cardiff-cli distribution name.

- updated README.md, REQUIREMENTS.md, CHANGELOG.md, CONTRIBUTING.md, and added docs/version-0-1-6-docs.md so the public release line, workflow guidance, and versioned documentation match the current repo state.

- verified python -m pytest tests/contract -q -p no:cacheprovider, python -m pytest tests/rendering -q -p no:cacheprovider, and python -m pytest tests/cli -q -p no:cacheprovider (9 passed, 25 passed, 14 passed).